### PR TITLE
Add config operators

### DIFF
--- a/RAKE/RAKE.py
+++ b/RAKE/RAKE.py
@@ -132,7 +132,7 @@ def generate_candidate_keyword_scores(phrase_list, word_score, minFrequency):
     for phrase in phrase_list:
         if phrase_list.count(phrase) >= minFrequency:
             keyword_candidates.setdefault(phrase, 0)
-            word_list = separate_words(phrase, 0)
+            word_list = separate_words(phrase)
             candidate_score = 0
             for word in word_list:
                 candidate_score += word_score[word]

--- a/RAKE/RAKE.py
+++ b/RAKE/RAKE.py
@@ -79,7 +79,7 @@ def split_sentences(text):
     Utility function to return a list of sentences.
     @param text The text that must be split in to sentences.
     """
-    sentence_delimiters = re.compile(u'[.!?,;:\t\\\\"\\(\\)\\\'\u2019\u2013]|\\s\\-\\s')
+    sentence_delimiters = re.compile(u'[.!?,;:\t\\\\"\\(\\)\\\'\u2019\u2013]|\\s\\-\\s') #upgrade as appropriate, fabian had changed version?
     sentences = sentence_delimiters.split(text)
     return sentences
 

--- a/RAKE/RAKE.py
+++ b/RAKE/RAKE.py
@@ -140,7 +140,7 @@ def generate_candidate_keyword_scores(phrase_list, word_score):
 
 
 class Rake(object):
-    def __init__(self, stop_words, regex='[\W\n]+'):
+    def __init__(self, stop_words, regex='[\W\n]+', minCharacters = 1, maxWords = 5, minFrequency = 1):
         #lets users call predefined stopwords easily in a platform agnostic manner or use their own list
         if isinstance(stop_words, list):
             self.__stop_words_pattern = build_stop_word_regex(stop_words)

--- a/RAKE/RAKE.py
+++ b/RAKE/RAKE.py
@@ -140,7 +140,7 @@ def generate_candidate_keyword_scores(phrase_list, word_score):
 
 
 class Rake(object):
-    def __init__(self, stop_words, regex='[\W\n]+', minCharacters = 1, maxWords = 5, minFrequency = 1):
+    def __init__(self, stop_words, regex = '[\W\n]+', minCharacters = 1, maxWords = 5, minFrequency = 1):
         #lets users call predefined stopwords easily in a platform agnostic manner or use their own list
         if isinstance(stop_words, list):
             self.__stop_words_pattern = build_stop_word_regex(stop_words)

--- a/RAKE/RAKE.py
+++ b/RAKE/RAKE.py
@@ -130,12 +130,13 @@ def calculate_word_scores(phraseList):
 def generate_candidate_keyword_scores(phrase_list, word_score, minFrequency):
     keyword_candidates = {}
     for phrase in phrase_list:
-        keyword_candidates.setdefault(phrase, 0)
-        word_list = separate_words(phrase, 0)
-        candidate_score = 0
-        for word in word_list:
-            candidate_score += word_score[word]
-        keyword_candidates[phrase] = candidate_score
+        if phrase_list.count(phrase) >= minFrequency:
+            keyword_candidates.setdefault(phrase, 0)
+            word_list = separate_words(phrase, 0)
+            candidate_score = 0
+            for word in word_list:
+                candidate_score += word_score[word]
+            keyword_candidates[phrase] = candidate_score
     return keyword_candidates
 
 

--- a/RAKE/RAKE.py
+++ b/RAKE/RAKE.py
@@ -92,14 +92,14 @@ def build_stop_word_regex(stop_word_list):
     return re.compile('|'.join(stop_word_regex_list), re.IGNORECASE)
 
 
-def generate_candidate_keywords(sentence_list, stopword_pattern):
+def generate_candidate_keywords(sentence_list, stop_word_pattern, minCharacters, maxWords):
     phrase_list = []
     for s in sentence_list:
-        tmp = re.sub(stopword_pattern, '|', s.strip())
+        tmp = re.sub(stop_word_pattern, '|', s.strip())
         phrases = tmp.split("|")
         for phrase in phrases:
             phrase = phrase.strip().lower()
-            if phrase != "":
+            if phrase != '' and len(phrase) >= minCharacters and len(phrase.split()) <= maxWords:
                 phrase_list.append(phrase)
     return phrase_list
 

--- a/RAKE/RAKE.py
+++ b/RAKE/RAKE.py
@@ -127,7 +127,7 @@ def calculate_word_scores(phraseList):
     return word_score
 
 
-def generate_candidate_keyword_scores(phrase_list, word_score):
+def generate_candidate_keyword_scores(phrase_list, word_score, minFrequency):
     keyword_candidates = {}
     for phrase in phrase_list:
         keyword_candidates.setdefault(phrase, 0)
@@ -158,7 +158,7 @@ class Rake(object):
 
         word_scores = calculate_word_scores(phrase_list)
 
-        keyword_candidates = generate_candidate_keyword_scores(phrase_list, word_scores)
+        keyword_candidates = generate_candidate_keyword_scores(phrase_list, word_scores, self.__minFrequency)
 
         sorted_keywords = sorted(keyword_candidates.items(), key=operator.itemgetter(1), reverse=True)
         return sorted_keywords

--- a/RAKE/RAKE.py
+++ b/RAKE/RAKE.py
@@ -146,6 +146,10 @@ class Rake(object):
             self.__stop_words_pattern = build_stop_word_regex(stop_words)
         else:
             self.__stop_words_pattern = build_stop_word_regex(load_stop_words(stop_words, regex))
+            
+        self.__minCharacters = minCharacters
+        self.__maxWords = maxWords
+        self.__minFrequency=minFrequency
 
     def run(self, text):
         sentence_list = split_sentences(text)

--- a/RAKE/RAKE.py
+++ b/RAKE/RAKE.py
@@ -58,7 +58,7 @@ def load_stop_words(stop_word_file, regex):
     return [word for word in stop_words if word not in ('', ' ')]  # filters empty string matches
 
 
-def separate_words(text, min_word_return_size):
+def separate_words(text):
     """
     Utility function to return a list of all words that are have a length greater than a specified number of characters.
     @param text The text that must be split in to words.
@@ -69,7 +69,7 @@ def separate_words(text, min_word_return_size):
     for single_word in splitter.split(text):
         current_word = single_word.strip().lower()
         # leave numbers in phrase, but don't count as words, since they tend to invalidate scores of their phrases
-        if len(current_word) > min_word_return_size and current_word != '' and not is_number(current_word):
+        if current_word != '' and not is_number(current_word):
             words.append(current_word)
     return words
 
@@ -108,7 +108,7 @@ def calculate_word_scores(phraseList):
     word_frequency = {}
     word_degree = {}
     for phrase in phraseList:
-        word_list = separate_words(phrase, 0)
+        word_list = separate_words(phrase)
         word_list_length = len(word_list)
         word_list_degree = word_list_length - 1
         for word in word_list:

--- a/RAKE/RAKE.py
+++ b/RAKE/RAKE.py
@@ -149,12 +149,12 @@ class Rake(object):
             
         self.__minCharacters = minCharacters
         self.__maxWords = maxWords
-        self.__minFrequency=minFrequency
+        self.__minFrequency = minFrequency
 
     def run(self, text):
         sentence_list = split_sentences(text)
 
-        phrase_list = generate_candidate_keywords(sentence_list, self.__stop_words_pattern)
+        phrase_list = generate_candidate_keywords(sentence_list, self.__stop_words_pattern, self.__minCharacters, self.__maxWords, )
 
         word_scores = calculate_word_scores(phrase_list)
 

--- a/RAKE/RAKE.py
+++ b/RAKE/RAKE.py
@@ -64,7 +64,7 @@ def separate_words(text, min_word_return_size):
     @param text The text that must be split in to words.
     @param min_word_return_size The minimum no of characters a word must have to be included.
     """
-    splitter = re.compile('[^a-zA-Z0-9_\\+\\-/]')
+    splitter = re.compile('/W+')
     words = []
     for single_word in splitter.split(text):
         current_word = single_word.strip().lower()

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ For lists:
     Rake = RAKE.Rake(<list>); #takes stopwords as list of strings
     Rake.run(text)
 
-`RAKE.SmartStopList()`, `RAKE.FoxStopList()`, `NLTKStopList()` and `MySQLStopList` return the expected lists as lists, they can be used as shown bellow. `GoogleSearchStopList()` returns what were thought to be stop words in Google search back when large numbers of search suggestions very available. `RanksNLStopList()` and `RanksNLStopList()` returns the in-house developed stoplists from Ranks NL, a webmaster suite. 
+`RAKE.SmartStopList()`, `RAKE.FoxStopList()`, `NLTKStopList()` and `MySQLStopList` return the expected lists as lists, they can be used as shown bellow. `GoogleSearchStopList()` returns what were thought to be stop words in Google search back when large numbers of search suggestions very available. `RanksNLStopList()` and `RanksNLLongStopList()` returns the in-house developed stoplists from Ranks NL, a webmaster suite. 
 
     import RAKE
     Rake = RAKE.Rake(RAKE.SmartStopList())

--- a/README.md
+++ b/README.md
@@ -21,23 +21,31 @@ Takes path as string datatype. Words can be on same or different lines but must 
 
     import RAKE
     Rake = RAKE.Rake(<path_to_your_stopwords_file>)
-    Rake.run(text);
+    Rake.run(<text>);
 
 To change how a file is read-in, simply use the code below. The built in regex described above is [\W\n]+.
 
-    `RAKE.Rake(<path_to_your_stopwords_file> , regex = '<your regex>' )`
+    `RAKE.Rake(<path_to_your_stopwords_file> , regex = '<your regex>')`
 
 For lists:
 
     import RAKE
     Rake = RAKE.Rake(<list>); #takes stopwords as list of strings
-    Rake.run(text)
+    Rake.run(<text>)
 
 `RAKE.SmartStopList()`, `RAKE.FoxStopList()`, `NLTKStopList()` and `MySQLStopList` return the expected lists as lists, they can be used as shown bellow. `GoogleSearchStopList()` returns what were thought to be stop words in Google search back when large numbers of search suggestions very available. `RanksNLStopList()` and `RanksNLLongStopList()` returns the in-house developed stoplists from Ranks NL, a webmaster suite. 
 
     import RAKE
     Rake = RAKE.Rake(RAKE.SmartStopList())
-    Rake.run(text)
+    Rake.run(<text>)
+    
+Additional flags:
+    
+The RAKE.rake function also accepts minCharacters, maxWords and minFrequency flags to better tune your outputs. minCharacters is the minimum characters allowed in a keyword. maxWords is the maximum number of words allowed in a phrase considered as a keyword. minFrequency is the minimum number of occurances a keyword has to have to be considered as a keyword. An example of this which shows the default values is as follows:
+
+    import RAKE
+    Rake = RAKE.Rake(RAKE.SmartStopList())
+    Rake.run(<text>, minCharacters = 1, maxWords = 5, minFrequency = 1)
 
 Other stoplists and stoplists in other languages can be found at https://github.com/trec-kba/many-stop-words/tree/master/orig, at http://www.ranks.nl/stopwords and in the NLTK stopwords package
     

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Takes path as string datatype. Words can be on same or different lines but must 
     Rake = RAKE.Rake(<path_to_your_stopwords_file>)
     Rake.run(<text>);
 
-To change how a file is read-in, simply use the code below. The built in regex described above is [\W\n]+.
+To change how a file is read-in, simply use the code below. The default regex described above is [\W\n]+.
 
     `RAKE.Rake(<path_to_your_stopwords_file> , regex = '<your regex>')`
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The source code is released under the MIT License.
 
 ### Usage ###
 For external `.txt`, `.csv`, etc files:
-Take path as string datatype. words can be on same or different lines but must be seperated by non-word characters. This should support all languages as it's based on unicode, but please validate the results of and report any issues with non-western languages, as they haven't been thoroughly tested.
+Takes path as string datatype. Words can be on same or different lines but must be seperated by non-word characters. This should support all languages as it's based on unicode, but please validate the results of and report any issues with non-western languages, as they haven't been thoroughly tested.
 
     import RAKE
     Rake = RAKE.Rake(<path_to_your_stopwords_file>)

--- a/setup.py
+++ b/setup.py
@@ -25,10 +25,6 @@ setup(
     # Author details
     author='Tomás Pinho <me@tomaspinho.com>, Fabian von Feilitzsch <fabian@fabianism.us>',
     author_email='fabian@fabianism.us',
-
-    install_requires=[
-        'six'
-    ],
     
     # Choose your license
     license='MIT',

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,10 @@ setup(
     author='Tomás Pinho <me@tomaspinho.com>, Fabian von Feilitzsch <fabian@fabianism.us>',
     author_email='fabian@fabianism.us',
 
+    install_requires=[
+        'six'
+    ],
+    
     # Choose your license
     license='MIT',
 
@@ -53,9 +57,13 @@ setup(
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.1',
         'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
 
     # What does your project relate to?


### PR DESCRIPTION
PR #16 ported to the new code base, closing issue #11 . Also fixes #23 , misc small things and includes the mini branch I tried to pull earlier to fix a typo. This version is also more short/clear/pythonic than #16 in several places and should be a little faster. I also fixed a few small logical bugs I found in PR #16.

Couple things I didn't propagate over from yours:

You changed the word regex in build_stop_word_regex and I couldn't figure out why it was better so I didn't propagate the change.
You changed the word sentence in split_sentences and I couldn't figure out why it was better so I didn't propagate the change.
You set it to require phrases to have more characters than digits, but that'll super directly break me and anyone analyzing technical documents.
The six.iteritems in sorted_keywords shouldn't be needed based on tests/ your earlier tests.