### PR TITLE
Fix Issue #30 - Split words on U

### DIFF
--- a/RAKE/RAKE.py
+++ b/RAKE/RAKE.py
@@ -79,7 +79,7 @@ def split_sentences(text):
     Utility function to return a list of sentences.
     @param text The text that must be split in to sentences.
     """
-    sentence_delimiters = re.compile('[.!?,;:\t\\\\"\\(\\)\\\'\u2019\u2013]|\\s\\-\\s')
+    sentence_delimiters = re.compile(u'[.!?,;:\t\\\\"\\(\\)\\\'\u2019\u2013]|\\s\\-\\s')
     sentences = sentence_delimiters.split(text)
     return sentences
 


### PR DESCRIPTION
The regex-string is not in Unicode, thus the \u... control sequence does have unexpected behaviour.
Just try split_sentences("restaurant"), it will return ["resta", "rant"], which is obviously bad.

Adding a simple u to the Regex, will force python to interpret it in unicode and fix this issue.

Tested with python2.7