### PR TITLE
Updated  to explicitly use  for compatiblity support

### DIFF
--- a/RAKE/RAKE.py
+++ b/RAKE/RAKE.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import
 
 import re
 import operator
+import io
 
 __all__ = [
     'Rake',
@@ -63,7 +64,9 @@ def RanksNLStoplist():
 
 
 def load_stop_words(stop_word_file, regex):
-    with open(stop_word_file, encoding='utf8') as stop_word_file:
+    # Looks like using `io.open()` is needed for compatibility support
+    # https://stackoverflow.com/a/25050323/845248
+    with io.open(stop_word_file, encoding='utf8') as stop_word_file:
         stop_words = re.split(regex, stop_word_file.read())
     return [word for word in stop_words if word not in ('', ' ')]  # filters empty string matches
 

--- a/RAKE/RAKE.py
+++ b/RAKE/RAKE.py
@@ -64,8 +64,6 @@ def RanksNLStoplist():
 
 
 def load_stop_words(stop_word_file, regex):
-    # Looks like using `io.open()` is needed for compatibility support
-    # https://stackoverflow.com/a/25050323/845248
     with io.open(stop_word_file, encoding='utf8') as stop_word_file:
         stop_words = re.split(regex, stop_word_file.read())
     return [word for word in stop_words if word not in ('', ' ')]  # filters empty string matches


### PR DESCRIPTION
Was having an issue when trying to utilize a custom `stopwords.txt`file:
```
Rake = RAKE.Rake('Extraction/stopwords.txt')
```

It would produce the following error:
```
Traceback (most recent call last):
  File "Extraction/keyword_extraction.py", line 12, in <module>
    Rake = RAKE.Rake('Extraction/stopwords.txt')
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/RAKE/RAKE.py", line 160, in __init__
    self.__stop_words_pattern = build_stop_word_regex(load_stop_words(stop_words, regex))
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/RAKE/RAKE.py", line 66, in load_stop_words
    with open(stop_word_file, encoding='utf8') as stop_word_file:
TypeError: 'encoding' is an invalid keyword argument for this function
```

It appears that if you explicitly define `io.open` and not just the alias `open` that it is compatible across versions.

Currently using `Python 2.7.14`